### PR TITLE
Implemented Deletion On Right Clicking

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -9,6 +9,7 @@
 		@mousemove="mouseEnterPixel"
 		@mouseleave="dragging = false"
 		@click="clicked"
+		@contextmenu="clearPixel($event)"
 	/>
 </template>
 
@@ -123,6 +124,18 @@ export default Vue.extend({
 			// info.color = rightClickXorClearing ? '' : this.color;
 			// const oldColor = this.getColor(info.row, info.col);
 		},
+
+		clearPixel(e: MouseEvent) {
+			e.preventDefault();
+			if (this.readonly) {
+				return;
+			}
+			const { offsetX: x, offsetY: y } = e;
+			const fillMethod = this.ctx.clearRect;
+			this.ctx.fillStyle = '';
+			fillMethod.apply(this.ctx, [x - x % this.pixelSize, y - y % this.pixelSize, this.pixelSize, this.pixelSize]);
+		},
+
 		clearBoard() {
 			const { width, height } = this.ctx.canvas;
 			this.ctx.clearRect(0, 0, width, height);


### PR DESCRIPTION
Closes #15 
I know this disables the context menu and therefore the save as an image option won't be there, but I think it would be more convenient to provide a button the saves as an image right away instead of right-clicking, UX wise I think it's better.

Also, drag and clear is not working with right-clicking, but should it? 
I mean if we have two options for clearing, setting the `clearing` prop to true, and right-clicking. 
It makes more sense that the right-clicking is for the minor edits, and for bigger ones, setting the prop, dragging, and clearing.

What are your thoughts?